### PR TITLE
Prioritize keyword args over method calls if there are name collisions

### DIFF
--- a/informed-ruby/lib/informed.rb
+++ b/informed-ruby/lib/informed.rb
@@ -197,8 +197,8 @@ module Informed
         if also_log[:values]
           message[:values] = {}
           also_log[:values].each do |local|
-            message[:values][local] = keyword_arguments[local] if keyword_arguments.key?(local)
-            message[:values][local] = informee.send(local) if informee.respond_to?(local, true)
+            message[:values][local] ||= keyword_arguments[local] if keyword_arguments.key?(local)
+            message[:values][local] ||= informee.send(local) if informee.respond_to?(local, true)
           end
         end
         message

--- a/informed-ruby/test/informed_test.rb
+++ b/informed-ruby/test/informed_test.rb
@@ -25,12 +25,16 @@ module Spec
       "method with arguments output #{arg1} #{arg2}"
     end
 
-    def method_with_keyword_arguments(a_named_kwarg:, arg2:)
+    def method_with_keyword_arguments(a_named_kwarg:, arg2:, colliding_named_arg: nil)
       "method with named arguments output #{a_named_kwarg} #{arg2}"
     end
 
     def method_with_both_kinds_of_arguments(unnamed_arg, named_arg:)
       "method with both kinds of arguments output #{unnamed_arg} #{named_arg}"
+    end
+
+    def colliding_named_arg
+      "oh noes! this shouldnt be shown!"
     end
 
     def method_with_a_block
@@ -126,6 +130,18 @@ describe Informed do
           refute logs.empty?, "logs were empty!"
           logs.each do |log|
             assert_equal "hey", log[:values][:a_named_kwarg]
+          end
+        end
+      end
+
+      describe "when :also_log has { values: [:colliding_named_arg] }" do
+        let(:method_to_inform_on) { :method_with_keyword_arguments }
+        let(:also_log) { { values: [:colliding_named_arg] } }
+        it "logs the value of the other method" do
+          consumer.method_with_keyword_arguments(a_named_kwarg: "hey", arg2: "there", colliding_named_arg: "there")
+          refute logs.empty?, "logs were empty!"
+          logs.each do |log|
+            assert_equal "there", log[:values][:colliding_named_arg]
           end
         end
       end


### PR DESCRIPTION
Noticed this when there was a name collision with a method that took an argument, and informed would attempt to call that method despite the keyword argument already having been set and raising an error.