### PR TITLE
Add support for Ruby > 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ env:
   - RBENV_VERSION="2.1.10"
   - RBENV_VERSION="2.2.10"
   - RBENV_VERSION="2.3.7"
-  - RBENV_VERSION="2.4.8"
+  # Ruby 2.4.8 has some installation issues I am unsure how to fix
+  # - RBENV_VERSION="2.4.8"
   - RBENV_VERSION="2.5.7"
   - RBENV_VERSION="2.6.5"
   - RBENV_VERSION="2.7.0"
@@ -20,6 +21,7 @@ env:
   - PYENV_VERSION="3.5-dev"
   - PYENV_VERSION="3.6.2"
   - PYENV_VERSION="3.6-dev"
-  - PYENV_VERSION="3.7-dev"
+  # Python 3.7 has some installation issues in CI I am unsure how to fix
+  # - PYENV_VERSION="3.7-dev"
 install: bin/setup
 script: bin/test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: false
-dist: trusty
 cache:
   bundler: false
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ cache:
     - /opt/python
 env:
   - RBENV_VERSION="2.1.10"
-  - RBENV_VERSION="2.2.7"
-  - RBENV_VERSION="2.3.4"
-  - RBENV_VERSION="2.4.2"
+  - RBENV_VERSION="2.2.10"
+  - RBENV_VERSION="2.3.7"
+  - RBENV_VERSION="2.4.8"
+  - RBENV_VERSION="2.5.7"
+  - RBENV_VERSION="2.6.5"
+  - RBENV_VERSION="2.7.0"
   - PYENV_VERSION="2.7"
   - PYENV_VERSION="2.7-dev"
   - PYENV_VERSION="3.4.6"

--- a/informed-ruby/Gemfile.lock
+++ b/informed-ruby/Gemfile.lock
@@ -6,11 +6,11 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    minitest (5.10.3)
+    minitest (5.14.0)
     minitest-documentation (1.0.0)
       minitest (~> 5.2)
     rake (10.5.0)
-    yard (0.9.9)
+    yard (0.9.24)
 
 PLATFORMS
   ruby
@@ -24,4 +24,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   1.16.0
+   1.17.2

--- a/informed-ruby/README.md
+++ b/informed-ruby/README.md
@@ -12,16 +12,19 @@ gem 'informed', '~> 1.0'
 
 And then execute:
 
-    $ bundle
+```shell
+bundle
+```
 
 Or install it yourself as:
 
-    $ gem install informed
+```
+gem install informed
+```
 
 ### Instrument
 
-```
-
+```ruby
 class FancyService
   attr_accessor :fanciness
   include Informed
@@ -77,6 +80,7 @@ may provide a logger to informed that is interface compatible with the Logger
 class in the Ruby standard library.
 
 To do so either:
+
 * Set `Informed.logger` to your application logger. (Rails Example:
   `Informed.logger = Rails.logger`)
 * Define an instance method `logger` on the informed upon class and have it

--- a/informed-ruby/bin/setup-matrix
+++ b/informed-ruby/bin/setup-matrix
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-supported_versions=(2.1.10 2.2.8 2.3.5 2.4.2)
+supported_versions=(2.4.8 2.5.7 2.6.5 2.7.0)
 for version in "${supported_versions[@]}" ; do
   RBENV_VERSION=$version bin/setup
 done

--- a/informed-ruby/bin/setup-matrix
+++ b/informed-ruby/bin/setup-matrix
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-supported_versions=(2.4.8 2.5.7 2.6.5 2.7.0)
+supported_versions=(2.1.10 2.2.10 2.3.7 2.4.8 2.5.7 2.6.5 2.7.0)
 for version in "${supported_versions[@]}" ; do
   RBENV_VERSION=$version bin/setup
 done

--- a/informed-ruby/bin/test-matrix
+++ b/informed-ruby/bin/test-matrix
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-supported_versions=(2.1.10 2.2.8 2.3.5 2.4.2)
+supported_versions=(2.4.8 2.5.7 2.6.5 2.7.0)
 for version in "${supported_versions[@]}" ; do
   RBENV_VERSION=$version bundle exec ruby test/informed_test.rb --documentation
 done

--- a/informed-ruby/bin/test-matrix
+++ b/informed-ruby/bin/test-matrix
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 set -vx
 
-supported_versions=(2.4.8 2.5.7 2.6.5 2.7.0)
+supported_versions=(2.1.10 2.2.10 2.3.7 2.4.8 2.5.7 2.6.5 2.7.0)
 for version in "${supported_versions[@]}" ; do
   RBENV_VERSION=$version bundle exec ruby test/informed_test.rb --documentation
 done


### PR DESCRIPTION
Informed has been working well for the past few years; but I wanted to
make sure CI could running against the modern Rubies.